### PR TITLE
avoid Zlib when response body was plain

### DIFF
--- a/lib/heroku/api.rb
+++ b/lib/heroku/api.rb
@@ -68,7 +68,11 @@ module Heroku
       end
 
       if response.body && !response.body.empty?
-        response.body = Zlib::GzipReader.new(StringIO.new(response.body)).read
+        begin
+          response.body = Zlib::GzipReader.new(StringIO.new(response.body)).read
+        rescue Zlib::GzipFile::Error
+          # response body was not zipped
+        end
         begin
           response.body = Heroku::API::OkJson.decode(response.body)
         rescue


### PR DESCRIPTION
when the response body was too short, api.heroku.com doesn't
compress response body.
