### PR TITLE
Catching Excon::Errors::Errors fails with timeout in Heroku::API#request

### DIFF
--- a/lib/heroku/api.rb
+++ b/lib/heroku/api.rb
@@ -58,9 +58,7 @@ module Heroku
     def request(params, &block)
       begin
         response = @connection.request(params, &block)
-      rescue Excon::Errors::SocketError => error
-        raise error
-      rescue Excon::Errors::Error => error
+      rescue Excon::Errors::HTTPStatusError => error
         klass = case error.response.status
           when 401 then Heroku::API::Errors::Unauthorized
           when 402 then Heroku::API::Errors::VerificationRequired


### PR DESCRIPTION
Currently, timeouts are caught by `rescue Excon::Errors::Error`, but a `Excon::Errors::Timeout` doesn't have a `#response` method causing `undefined method 'response' for #<Excon::Errors::Timeout...`

Proposed change:

```
def request(params, &block)
  begin
    response = @connection.request(params, &block)
  rescue Excon::Errors::HTTPStatusError => error # Only HTTPStatusError has #response
    ...
  end # Raise on everything else
```
