### PR TITLE
Remove SHARED_DATABASE from mocks

### DIFF
--- a/lib/heroku/api/mock.rb
+++ b/lib/heroku/api/mock.rb
@@ -52,8 +52,7 @@ module Heroku
             'BUNDLE_WITHOUT'      => 'development:test',
             'DATABASE_URL'        => 'postgres://username:password@ec2-123-123-123-123.compute-1.amazonaws.com/username',
             'LANG'                => 'en_US.UTF-8',
-            'RACK_ENV'            => 'production',
-            'SHARED_DATABASE_URL' => 'postgres://username:password@ec2-123-123-123-123.compute-1.amazonaws.com/username'
+            'RACK_ENV'            => 'production'
           }
         else
           {}


### PR DESCRIPTION
No impact here, but fixes heroku/heroku#653
