### PR TITLE
Fix broken travis-ci build

### DIFF
--- a/heroku-api.gemspec
+++ b/heroku-api.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'excon', '~>0.19.0'
+  s.add_runtime_dependency 'excon', '~>0.20.0'
 
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
Bump to excon version with downgraded severity of invalid keys.
