### PR TITLE
Add custom exception when API rate limit is reached

### DIFF
--- a/lib/heroku/api.rb
+++ b/lib/heroku/api.rb
@@ -86,7 +86,7 @@ module Heroku
           when 408 then Heroku::API::Errors::Timeout
           when 422 then Heroku::API::Errors::RequestFailed
           when 423 then Heroku::API::Errors::Locked
-          when 429 then Heroku::API::Errors::APIRateLimit
+          when 429 then Heroku::API::Errors::RateLimitExceeded
           when /50./ then Heroku::API::Errors::RequestFailed
           else Heroku::API::Errors::ErrorWithResponse
         end


### PR DESCRIPTION
I ran into an issue this morning and I started catching the API exception when the rate limit is reached (status code = 429) and I thought it'd be nice to add this exception with the others:

Using it here in dashboard:

http://git.io/mdIgZA
