### PR TITLE
Don't send username and password when connecting only for login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .bundle
 Gemfile.lock
 pkg/*
+.rvmrc

--- a/lib/heroku/api.rb
+++ b/lib/heroku/api.rb
@@ -57,8 +57,10 @@ module Heroku
 
       @api_key = options.delete(:api_key) || ENV['HEROKU_API_KEY']
       if !@api_key && options.has_key?(:username) && options.has_key?(:password)
+        username = options.delete(:username)
+        password = options.delete(:password)
         @connection = Excon.new("#{options[:scheme]}://#{options[:host]}", options.merge(:headers => HEADERS))
-        @api_key = self.post_login(options[:username], options[:password]).body["api_key"]
+        @api_key = self.post_login(username, password).body["api_key"]
       end
 
       user_pass = ":#{@api_key}"


### PR DESCRIPTION
passing `username` to creating a connection causes a warning/error

https://github.com/heroku/heroku.rb/issues/53
