### PR TITLE
Deleting collaborators with email addresses that include a plus.

### DIFF
--- a/test/test_collaborators.rb
+++ b/test/test_collaborators.rb
@@ -70,4 +70,19 @@ class TestCollaborators < MiniTest::Unit::TestCase
     end
   end
 
+  def test_delete_collaborator
+    with_app do |app_data|
+      email_address = 'wesley+test@heroku.com'
+      heroku.post_collaborator(app_data['name'], email_address)
+
+      response = heroku.delete_collaborator(app_data['name'], email_address)
+
+      assert_equal(200, response.status)
+      assert_equal(
+        "#{email_address} has been removed as collaborator on #{app_data['name']}",
+        response.body
+      )
+    end
+  end
+
 end


### PR DESCRIPTION
- When using the actual API, trying to delete a collaborator with an
  email format of email+token@example.com returns a 404.

```
Heroku::API::Errors::NotFound: Expected(200) <=> Actual(404 Not Found)
```

I was able to solve this in my application by replacing `+` with `%2B` before making the call to `delete_collaborator`.

I added a test for deleting a collaborator, but this test currently passes. This problem doesn't seem like its too big of an issue, but I'm just curious as to what you guys think. I haven't dove into heroku.rb to think about a solution yet.
