### PR TITLE
Reclaim 402 status code

### DIFF
--- a/lib/heroku/api.rb
+++ b/lib/heroku/api.rb
@@ -77,7 +77,7 @@ module Heroku
       rescue Excon::Errors::HTTPStatusError => error
         klass = case error.response.status
           when 401 then Heroku::API::Errors::Unauthorized
-          when 402 then Heroku::API::Errors::VerificationRequired
+          when 402 then Heroku::API::Errors::PaymentRequired
           when 403 then Heroku::API::Errors::Forbidden
           when 404
             if error.request[:path].match /\/apps\/\/.*/

--- a/lib/heroku/api/errors.rb
+++ b/lib/heroku/api/errors.rb
@@ -13,6 +13,7 @@ module Heroku
       end
 
       class Unauthorized < ErrorWithResponse; end
+      class PaymentRequired < ErrorWithResponse; end
       class VerificationRequired < ErrorWithResponse; end
       class Forbidden < ErrorWithResponse; end
       class NotFound < ErrorWithResponse; end


### PR DESCRIPTION
402 was used previously in some cases where account confirmation was
required (it seems that the `VerificationRequired` exception here was a
misnomer), but confirmation is a concept that we're trying to deprecate
anyway as indicated in heroku/api#750.

Remove specialized use of 402, and make it a generic "Payment Required"
exception once again so that we can re-use it to signal account deliquency.
