### PR TITLE
Be more flexible about excon version.

### DIFF
--- a/heroku-api.gemspec
+++ b/heroku-api.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'excon', '~>0.27.0'
+  s.add_runtime_dependency 'excon', '~>0.27'
   s.add_runtime_dependency 'multi_json', '~>1.8.2'
 
   s.add_development_dependency 'minitest'


### PR DESCRIPTION
Every time `fog` updates to use a new version of `excon`, `heroku-api` needs to update in step. That seems silly.

Luckily, `excon` appears to be following semantic versioning. We should be able to use any version with a major number of `0`.

This would save me a whole lot of headaches. I'm sure I'm not alone.
