### PR TITLE
Relax multi_json dependency

### DIFF
--- a/heroku-api.gemspec
+++ b/heroku-api.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency 'excon', '~>0.27'
-  s.add_runtime_dependency 'multi_json', '~>1.8.2'
+  s.add_runtime_dependency 'multi_json', '~>1.8'
 
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
MultiJson uses semantic versioning, which means that there should be no breaking changes between minor version updates. I've recently released MultiJson 1.9.0 with lots of improvements and this dependency prevents people from updating.
