### PR TITLE
Add a v2 sunset warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Heroku Ruby Client
 
 The Heroku Ruby Client is used to interact with the [Heroku Legacy API](http://legacy-api-docs.herokuapp.com) from Ruby.
 
+:warning: **[The Legacy API will be sunset on April 15th, 2017](https://devcenter.heroku.com/changelog-items/862)** :warning:
+
 Where possible we recommend interacting instead with the [Heroku Platform API](https://devcenter.heroku.com/articles/platform-api-reference). You can use the [Ruby client](https://github.com/heroku/platform-api) with the Platform API (or just install the [gem](https://rubygems.org/gems/platform-api)).
 
 [![Build Status](https://travis-ci.org/heroku/heroku.rb.png)](https://travis-ci.org/heroku/heroku.rb)


### PR DESCRIPTION
Now that the v2 API sunset announcement has been made, add a warning to anyone using this library.

https://devcenter.heroku.com/changelog-items/862